### PR TITLE
Use distinct classes for hanging quote types.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -36,6 +36,88 @@ Beautiful <span class="amp">&amp;</span> Awesome Web Typography with <span class
 `&nbsp;` is shown here just for demonstration purposes. Actual implementation produces the non-breaking space character itself (`String.fromCharCode(160)`), not the escaped sequence.
 
 
+## Styles
+
+Richtypo wraps abbreviations in `<abbr>` tags. It also wraps ampersands and leading quotes to allow for typographic enhancement:
+
+<table>
+  <thead>
+    <tr>
+      <th>Character</th>
+      <th>Spacer class</th>
+      <th>Character class</th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td><code>&amp;</code></td>
+      <td></td>
+      <td><code>amp</code></td>
+    </tr>
+    <tr>
+      <td><code>“</code></td>
+      <td><code>sldquo</code></td>
+      <td><code>hldquo</code></td>
+    </tr>
+    <tr>
+      <td><code>‘</code></td>
+      <td><code>slsquo</code></td>
+      <td><code>hlsquo</code></td>
+    </tr>
+    <tr>
+      <td><code>«</code></td>
+      <td><code>slaquo</code></td>
+      <td><code>hlaquo</code></td>
+    </tr>
+    <tr>
+      <td><code>„</code></td>
+      <td><code>sbdquo</code></td>
+      <td><code>hbdquo</code></td>
+    </tr>
+    <tr>
+      <td><code>(</code></td>
+      <td><code>sbrace</code></td>
+      <td><code>hbrace</code></td>
+    </tr>
+   </tbody>
+</table>
+
+
+Start with something like this, and customize it for your site:
+
+```css
+/* Use small caps for abbreviations */
+abbr {
+  font-size: 0.875em;
+  letter-spacing: 0.15em;
+  margin-right: -0.15em;
+}
+
+/* Use the best available ampersand */
+.amp {
+  font-family: Baskerville, Constantia, Palatino, 'Palatino Linotype', 'Book Antiqua', serif;
+  font-style: italic;
+}
+
+/* Hang leading braces and quotes into the left margin */
+.sbrace { margin-right: 0.3em;  }
+.hbrace { margin-left: -0.3em;  }
+
+.slaquo { margin-right: 0.42em; }
+.hlaquo { margin-left: -0.42em; }
+
+.sbdquo { margin-right: 0.42em; }
+.hbdquo { margin-left: -0.42em; }
+
+.sldquo { margin-right: 0.42em; }
+.hldquo { margin-left: -0.42em; }
+
+.slsquo { margin-right: 0.42em; }
+.hlsquo { margin-left: -0.42em; }
+```
+
+
 ## Installation
 
 ```bash

--- a/Readme.md
+++ b/Readme.md
@@ -30,7 +30,7 @@ Will produce something like that:
 
 ```html
 Welcome to&nbsp;the world of&nbsp;beautiful web typography&nbsp;— only with Richtypo.
-Beautiful <span class="amp">&amp;</span> Awesome Web Typography with <span class="slaquo"> </span> <span class="hlaquo">“</span>Richtypo”'
+Beautiful <span class="amp">&amp;</span> Awesome Web Typography with <span class="sldquo"> </span> <span class="hldquo">“</span>Richtypo”'
 ```
 
 `&nbsp;` is shown here just for demonstration purposes. Actual implementation produces the non-breaking space character itself (`String.fromCharCode(160)`), not the escaped sequence.

--- a/example/sample.css
+++ b/example/sample.css
@@ -51,3 +51,21 @@ abbr {
 .hlaquo {
 	margin-left: -0.42em;
 	}
+.sbdquo {
+	margin-right: 0.42em;
+	}
+.hbdquo {
+	margin-left: -0.42em;
+	}
+.sldquo {
+	margin-right: 0.42em;
+	}
+.hldquo {
+	margin-left: -0.42em;
+	}
+.slsquo {
+	margin-right: 0.42em;
+	}
+.hlsquo {
+	margin-left: -0.42em;
+	}

--- a/richtypo.js
+++ b/richtypo.js
@@ -44,9 +44,9 @@ var commonRules = {
 	// Hanging punctuation
 	_hanging_table: {
 		'«': 'laquo',
-		'„': 'laquo',
-		'“': 'laquo',
-		'‘': 'laquo',
+		'„': 'bdquo',
+		'“': 'ldquo',
+		'‘': 'lsquo',
 		'(': 'brace',
 	},
 	hanging: [

--- a/test/test.spec.js
+++ b/test/test.spec.js
@@ -180,7 +180,7 @@ describe('RichTypo', function() {
 			.toBe('<!--[if lte IE 6]><script>alert("wheee");</script><style>* { color: red; }</style><pre>...</pre><![endif]-->');
 
 		expect(rt.title('<!--[if lte IE 6]>The “quoted text.”<![endif]-->'))
-			.toBe('<!--[if lte IE 6]>The<span class="slaquo"> </span> <span class="hlaquo">“</span>quoted text.”<![endif]-->');
+			.toBe('<!--[if lte IE 6]>The<span class="sldquo"> </span> <span class="hldquo">“</span>quoted text.”<![endif]-->');
 	});
 
 });

--- a/test/test.spec.js
+++ b/test/test.spec.js
@@ -153,10 +153,10 @@ describe('RichTypo', function() {
 
 	it('hanging', function() {
 		expect(rt.title('The “quoted text.”'))
-			.toBe(_symb('The<span class="slaquo"> </span> <span class="hlaquo">“</span>quoted text.”'));
+			.toBe(_symb('The<span class="sldquo"> </span> <span class="hldquo">“</span>quoted text.”'));
 
 		expect(rt.title('“Quoted text” two.'))
-			.toBe(_symb('<span class="hlaquo">“</span>Quoted text” two.'));
+			.toBe(_symb('<span class="hldquo">“</span>Quoted text” two.'));
 
 		expect(rt.title('alert("Hello world!")'))
 			.toBe(_symb('alert("Hello world!")'));


### PR DESCRIPTION
For the two fonts on my site, every quote type needs a different indent value. This changeset allows styling them individually:

```less
.sbrace { margin-right: 0.33em; }
.hbrace { margin-left: -0.33em; }

.slaquo { margin-right: 0.525em; }
.hlaquo { margin-left: -0.525em; }

.sbdquo { margin-right: 0.4em; }
.hbdquo { margin-left: -0.4em; }

.sldquo { margin-right: 0.4em; }
.hldquo { margin-left: -0.4em; }

.slsquo { margin-right: 0.315em; }
.hlsquo { margin-left: -0.315em; }

h1, h2, h3, h4 {
    .sbrace { margin-right: 0.35em; }
    .hbrace { margin-left: -0.35em; }

    .slaquo { margin-right: 0.56em; }
    .hlaquo { margin-left: -0.56em; }

    .sbdquo { margin-right: 0.33em; }
    .hbdquo { margin-left: -0.33em; }

    .sldquo { margin-right: 0.52em; }
    .hldquo { margin-left: -0.52em; }

    .slsquo { margin-right: 0.295em; }
    .hlsquo { margin-left: -0.295em; }
}
```

Note that I didn't update the example, as I wasn't quite sure how to do that. I'd be happy to update that and add a contributing.md if you let me know how to do it :)