### PR TITLE
Improve comment support

### DIFF
--- a/richtypo.js
+++ b/richtypo.js
@@ -18,11 +18,11 @@ var rules = {},
 	savedTagsNum,
 	savedTags,
 	saveTagsRe = [
+		/<!--[\s\S]*?-->/mig,
 		/<pre[^>]*>[\s\S]*?<\/pre>/mig,
 		/<style[^>]*>[\s\S]*?<\/style>/mig,
 		/<script[^>]*>[\s\S]*?<\/script>/mig,
 		/<code[^>]*>[\s\S]*?<\/code>/mig,
-		/<!--[\s\S]*?-->/mig,
 		/<[a-z\/][^>]*>/mig
 	],
 	restoreTagsRe = /<(\d+)>/g,

--- a/richtypo.js
+++ b/richtypo.js
@@ -18,6 +18,7 @@ var rules = {},
 	savedTagsNum,
 	savedTags,
 	saveTagsRe = [
+		/<!(--\[[^\]>]+\]|\[[^\]>]+\]--)>/mig,
 		/<!--[\s\S]*?-->/mig,
 		/<pre[^>]*>[\s\S]*?<\/pre>/mig,
 		/<style[^>]*>[\s\S]*?<\/style>/mig,

--- a/test/test.spec.js
+++ b/test/test.spec.js
@@ -170,4 +170,9 @@ describe('RichTypo', function() {
 				.toBe('— Бадыдыщь!\n— Бадыдыщь!');
 	});
 
+	it('leaves commented out tags alone', function() {
+		expect(rt.lite('<!-- <script>alert("wheee");</script><style>* { color: red; }</style><pre>...</pre> -->'))
+			.toBe('<!-- <script>alert("wheee");</script><style>* { color: red; }</style><pre>...</pre> -->');
+	});
+
 });

--- a/test/test.spec.js
+++ b/test/test.spec.js
@@ -175,4 +175,12 @@ describe('RichTypo', function() {
 			.toBe('<!-- <script>alert("wheee");</script><style>* { color: red; }</style><pre>...</pre> -->');
 	});
 
+	it('plays nice with ie conditional comments', function() {
+		expect(rt.title('<!--[if lte IE 6]><script>alert("wheee");</script><style>* { color: red; }</style><pre>...</pre><![endif]-->'))
+			.toBe('<!--[if lte IE 6]><script>alert("wheee");</script><style>* { color: red; }</style><pre>...</pre><![endif]-->');
+
+		expect(rt.title('<!--[if lte IE 6]>The “quoted text.”<![endif]-->'))
+			.toBe('<!--[if lte IE 6]>The<span class="slaquo"> </span> <span class="hlaquo">“</span>quoted text.”<![endif]-->');
+	});
+
 });


### PR DESCRIPTION
Handle commented out tags and IE conditional comments.

Previously, a commented out tag, e.g. `<!-- <pre>wat</pre> -->` would render as `<!-- <1> -->`. Moving the comment regexp to the front keeps other replacements from interfering with it.

Additionally, since an IE conditional comment is technically just a comment, richtypo didn't support anything inside them. Adding a specific handler for IE conditional comments means that the contents are improved just like normal HTML.