### PR TITLE
Fix double quote parser

### DIFF
--- a/packages/richtypo-rules-common/src/common.js
+++ b/packages/richtypo-rules-common/src/common.js
@@ -121,7 +121,7 @@ export const numberSeparatorsFactory = ({
 export const quotesFactory = ({ openingQuote, closingQuote }) => text =>
 	text
 		.replace(
-			new RegExp(`${notInTag}"((${tag})?(${dash}${space})?${letter})`, 'gmi'),
+			new RegExp(`${notInTag}(["“«]|&ldquo;)((${tag})?(${dash}${space})?${letter})`, 'gmi'),
 			`${openingQuote}$1`
 		)
-		.replace(new RegExp(`${notInTag}"`, 'gmi'), `${closingQuote}`);
+		.replace(new RegExp(`${notInTag}(["”»]|&rdquo;)`, 'gmi'), `${closingQuote}`);

--- a/packages/richtypo-rules-common/src/common.js
+++ b/packages/richtypo-rules-common/src/common.js
@@ -122,6 +122,6 @@ export const quotesFactory = ({ openingQuote, closingQuote }) => text =>
 	text
 		.replace(
 			new RegExp(`${notInTag}(["“«]|&ldquo;)((${tag})?(${dash}${space})?${letter})`, 'gmi'),
-			`${openingQuote}$1`
+			`${openingQuote}$2`
 		)
 		.replace(new RegExp(`${notInTag}(["”»]|&rdquo;)`, 'gmi'), `${closingQuote}`);


### PR DESCRIPTION
I use your library to update html with french typography, It's a very good taff :+1:

I use it after gohugo compile my html so `"` is already changed to `&ldquo;` or `&rdquo;` with this fix my code convert `&ldquo;` to `« ` and `&rdquo;` to ` »`

I created a special rule while waiting for the fix, my script:

```js
'use strict';

const path = require('path');
const { loadSourceFiles, savePages } = require('fledermaus');
const richtypo = require('richtypo');
const frRules = require('richtypo-rules-fr');
const { definitions } = require('richtypo-rules-common');

console.log('Prepares your texts to publication on web: applies typography rules.');

const openingQuote = '«';
const closingQuote = '»';
const quotes = text => text
  .replace(
    new RegExp(`${definitions.notInTag}(["“«]|&ldquo;)((${definitions.tag})?(${definitions.dash}${definitions.space})?${definitions.letter})`, 'gmi'),
    `${openingQuote}$2`
  )
  .replace(
    new RegExp(`${definitions.notInTag}(["”»]|&rdquo;)`, 'gmi'),
    `${closingQuote}`
  );

const rt = richtypo.default([frRules.default, quotes]);

let documents = loadSourceFiles(path.resolve(__dirname, 'public'), ['html'], {});

const pages = documents.map(doc => {
  return {
    pagePath: doc.sourcePath,
    content: rt(doc.content),
  };
});

savePages(pages, path.resolve(__dirname, 'public'));
```